### PR TITLE
Clear the interval to stop it trying to fire when the progress meter is no longer on the page

### DIFF
--- a/resources/views/livewire/game-view.blade.php
+++ b/resources/views/livewire/game-view.blade.php
@@ -491,8 +491,6 @@
         </div>
     </div>
 
-    <div x-on:forfeit-handler.window="$wire.handleForfeit()"></div>
-
     <template x-if="player_forfeits_at">
         <div class="w-[240px] mt-4">
             <div 
@@ -501,6 +499,11 @@
                     isUrgent: false,
                     hasExpired: false,
                     updateProgress() {
+                        if (! player_forfeits_at) {
+                            clearInterval(this.progressInterval)
+
+                            return
+                        }
                         const now = new Date();
                         const forfeitTime = new Date(this.player_forfeits_at);
                         const startTime = new Date(forfeitTime - 60000);
@@ -512,13 +515,14 @@
                         // Check if timer just hit zero and hasn't been handled yet
                         if (!this.hasExpired && now >= forfeitTime) {
                             this.hasExpired = true;
-                            this.$dispatch('forfeit-handler');
+                            $wire.handleForfeit();
                         }
-                    }
+                    },
+                    progressInterval: null
                 }"
                 x-init="
                     updateProgress();
-                    setInterval(() => updateProgress(), 100)
+                    progressInterval = setInterval(() => updateProgress(), 100)
                 "
                 class="h-2 bg-gray-200 rounded-full overflow-hidden"
             >


### PR DESCRIPTION
The problem was the `updateProgress()` method kept firing after the progress meter was remove from the page, because of the `x-if`, because the interval timer was firing it. So when it got to the `$wire.handleForfeit()` bit, it was calling it, but couldn't find the Livewire component that it was inside of, because the element had been removed from the page.

So this PR adds a check to `updateProgress()` to see if the progress still exists on the page and if it doesn't then it cancels the interval timer and returns early.