### PR TITLE
Show victory state optimistically

### DIFF
--- a/app/Livewire/GameView.php
+++ b/app/Livewire/GameView.php
@@ -284,11 +284,11 @@ class GameView extends Component
 
     public function handleForfeit()
     {
-        GameForfeited::fire(
-            game_id: $this->game->id,
-            loser_id: $this->player->id,
-            winner_id: $this->opponent->id,
-        );
+        // GameForfeited::fire(
+        //     game_id: $this->game->id,
+        //     loser_id: $this->player->id,
+        //     winner_id: $this->opponent->id,
+        // );
     }
 
     public function sendFriendRequest()

--- a/app/Livewire/GameView.php
+++ b/app/Livewire/GameView.php
@@ -284,11 +284,11 @@ class GameView extends Component
 
     public function handleForfeit()
     {
-        // GameForfeited::fire(
-        //     game_id: $this->game->id,
-        //     loser_id: $this->player->id,
-        //     winner_id: $this->opponent->id,
-        // );
+        GameForfeited::fire(
+            game_id: $this->game->id,
+            loser_id: $this->player->id,
+            winner_id: $this->opponent->id,
+        );
     }
 
     public function sendFriendRequest()

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -20,4 +20,8 @@
     }
 }
 
-.victory-wave-glow { animation: victory-wave-glow 1.5s ease-in-out infinite; border-radius: 0.75rem; }
+.victory-wave-glow { 
+    animation: victory-wave-glow 1.5s ease-in-out infinite; 
+    border-radius: 0.75rem; 
+    z-index: 10; 
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,1 +1,4 @@
 import './bootstrap';
+import { victory_status } from './game/game-logic.js';
+
+window.victory_status = victory_status;

--- a/resources/js/game/game-logic.js
+++ b/resources/js/game/game-logic.js
@@ -1,4 +1,4 @@
-export function checkForVictory(tiles, victoryShape, playerId) {
+export function victory_status(tiles, victoryShape, playerId) {
     const possibleVictorySets = getPossibleVictorySets(victoryShape);
     
     const board = tiles.reduce((acc, tile) => {

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -14,7 +14,7 @@
     </head>
     <body class="min-h-screen bg-white dark:bg-slate-900 text-zinc-800 dark:text-zinc-200">
         @if (auth()->user())
-            <flux:sidebar sticky stashable class="border-r bg-white dark:bg-slate-900 border-zinc-200 dark:border-zinc-700">
+            <flux:sidebar sticky stashable class="border-r bg-white dark:bg-slate-900 border-zinc-200 dark:border-zinc-700 z-20">
                 <flux:sidebar.toggle class="lg:hidden" icon="x-mark" />
         
                 <div class="flex flex-row space-x-4 items-center">

--- a/resources/views/livewire/game-view.blade.php
+++ b/resources/views/livewire/game-view.blade.php
@@ -243,10 +243,7 @@
                 player_victory_status = victory_status(this.tiles, this.player_victory_shape, this.player_id);
                 opponent_victory_status = victory_status(this.tiles, this.opponent_victory_shape, this.opponent_id);
 
-                console.log(player_victory_status, opponent_victory_status);
-
                 if (player_victory_status.has_won) {
-                    console.log('PLAYER WON');
                     this.victor_ids.push(this.player_id);
                     this.game_status = 'completed';
                     this.winning_spaces.push(player_victory_status.winning_spaces);
@@ -254,17 +251,11 @@
                 }
 
                 if (opponent_victory_status.has_won) {
-                    console.log('OPPONENT WON');
                     this.victor_ids.push(this.opponent_id);
                     this.game_status = 'completed';
                     this.winning_spaces.push(opponent_victory_status.winning_spaces);
                     this.player_forfeits_at = null;
                 }
-
-                console.log('victors', this.victor_ids);
-                console.log('status', this.game_status);
-                console.log( 'spaces', this.winning_spaces);
-                console.log('player_forfeits_at', this.player_forfeits_at);
             },
 
             init() {

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,8 +6,7 @@ export default defineConfig({
         laravel({
             input: [
                 'resources/css/app.css',
-                'resources/js/app.js',
-                'resources/js/game/game-logic.js'
+                'resources/js/app.js'
             ],
             refresh: true,
         }),


### PR DESCRIPTION
we had a problem where we needed to wait on a server event to know that we had won the game. This is ok if the opponent won, because we learn about their winning move and their victory status at basically the same time. But if YOU win, you have to wait for the server to tell you before we can update the client animations. Now the client checks for itself. 