### PR TITLE
Fix turn timer

### DIFF
--- a/app/Livewire/GameView.php
+++ b/app/Livewire/GameView.php
@@ -203,6 +203,10 @@ class GameView extends Component
             'left' => ($prior_tile_move->initial_slide['space'] / 4) - 1,
         };
 
+        if($this->player->fresh()->forfeits_at === null) {
+            dd('very bad');
+        }
+
         $this->dispatch('opponent-moved-elephant', [
             'elephant_move_position' => $move->elephant_after,
             'player_id' => (string) $move->player_id,

--- a/app/Livewire/GameView.php
+++ b/app/Livewire/GameView.php
@@ -203,10 +203,6 @@ class GameView extends Component
             'left' => ($prior_tile_move->initial_slide['space'] / 4) - 1,
         };
 
-        if($this->player->fresh()->forfeits_at === null) {
-            dd('very bad');
-        }
-
         $this->dispatch('opponent-moved-elephant', [
             'elephant_move_position' => $move->elephant_after,
             'player_id' => (string) $move->player_id,

--- a/resources/views/livewire/game-view.blade.php
+++ b/resources/views/livewire/game-view.blade.php
@@ -80,7 +80,10 @@
             },
 
             moveElephant(player_id, space) {
-                this.player_forfeits_at = null;
+                if (player_id === this.player_id) {
+                    this.player_forfeits_at = null;
+                }
+
                 this.animating = true;
                 this.elephant_space = space;
                 const coords = this.spaceToCoords(space);
@@ -296,11 +299,12 @@
                 });
 
                 this.$wire.on('opponent-moved-elephant', (data) => {
+                    this.player_forfeits_at = data[0].player_forfeits_at;
                     this.playTile(data[0].tile_direction, data[0].tile_position, data[0].player_id);
+
                     setTimeout(() => {
                         this.moveElephant(data[0].player_id, data[0].elephant_move_position);
                     }, 700);
-                    this.player_forfeits_at = data[0].player_forfeits_at;
                 });
 
                 this.$wire.on('friend-status-changed', (data) => {


### PR DESCRIPTION
there was a bug where we were setting `player_forfeits_at` to null any time the elephant moved. 