### PR TITLE
Better mobile view for joining games

### DIFF
--- a/resources/views/livewire/home-page.blade.php
+++ b/resources/views/livewire/home-page.blade.php
@@ -93,12 +93,10 @@
                             <div wire:key="game-{{ $game['id'] }}">
                                 <flux:row>
                                     <flux:cell>
-                                        <div class="flex items-center gap-2">
+                                        <div class="flex items-center gap-2 text-xs">
                                             {{ $game['player'] }}
-                                            <flux:badge color="gray" size="sm" variant="outline">{{ $game['rating'] }}</flux:badge>
-                                            @if ($game['is_friend'])
-                                                <flux:badge size="sm" color="green">Friend</flux:badge>
-                                            @endif
+                                            <flux:badge color="gray" size="sm" variant="outline" icon="star">{{ $game['rating'] }}</flux:badge>
+                                       
                                             @if ($game['is_ranked'])
                                                 <flux:badge size="sm" color="fuchsia">Ranked</flux:badge>
                                             @endif


### PR DESCRIPTION
Previously we showed friend status, and it was just too cluttered. It caused a scroll on the join game table, which is bad.

<img width="370" alt="Screenshot 2024-12-24 at 4 33 52 PM" src="https://github.com/user-attachments/assets/43516f76-ebf0-467f-8636-8f0ae59bd636" />


now it's better