### PR TITLE
Handle cats game

### DIFF
--- a/app/Events/PlayerPlayedTile.php
+++ b/app/Events/PlayerPlayedTile.php
@@ -176,7 +176,9 @@ class PlayerPlayedTile extends Event
             'initial_slide' => ['space' => $this->space, 'direction' => $this->direction],
         ]);
 
-        if (count($game->victor_ids) > 0) {
+        $player_hands_are_empty = $game_model->players->sum(fn($p) => $p->hand) === 0;
+
+        if (count($game->victor_ids) > 0 || $player_hands_are_empty) {
             PlayerPlayedTileBroadcast::dispatch($game_model, $move);
 
             $game_model->players->each(function ($player) {

--- a/resources/views/livewire/game-view.blade.php
+++ b/resources/views/livewire/game-view.blade.php
@@ -86,8 +86,12 @@
             },
 
             moveElephant(player_id, space) {
-                if (player_id === this.player_id) {
+                if (player_id === this.player_id && this.opponent_hand > 0) {
                     this.player_forfeits_at = null;
+                }
+
+                if (player_id === this.player_id && this.opponent_hand === 0) {
+                    this.player_forfeits_at = new Date(Date.now() + 30000).toISOString();
                 }
 
                 this.animating = true;
@@ -267,6 +271,11 @@
                         this.winning_spaces.push(...opponent_victory_status.winning_spaces);
                         this.player_forfeits_at = null;
                         this.opponent_is_victor = true;
+                    }
+
+                    if (this.player_hand === 0 && this.opponent_hand === 0 && this.game_status === 'active') {
+                        this.game_status = 'complete';
+                        this.player_forfeits_at = null;
                     }
                 }, 500);
             },


### PR DESCRIPTION
Fixed two end game bugs: 

1. If your opponent was out of tiles, and you played your turn, it still showed the "opponent is thinking..." because it thought it wasn't your turn anymore
2. if both players are out of tiles (which should be a ridiculously rare edge case), the client showed a weird, incorrect state. Now it clearly shows the game is over