### PR TITLE
Allow game creator to forego first move

### DIFF
--- a/app/Events/GameStarted.php
+++ b/app/Events/GameStarted.php
@@ -26,30 +26,6 @@ class GameStarted extends Event
         $state->victor_ids = [];
     }
 
-    public function fired()
-    {
-        $game = $this->state(GameState::class);
-
-        if ($game->currentPlayer()->is_bot) {
-            $bot_tile_move = $game->selectBotTileMove($game->board);
-
-            PlayerPlayedTile::fire(
-                game_id: $this->game_id,
-                player_id: $game->current_player_id,
-                space: $bot_tile_move['space'],
-                direction: $bot_tile_move['direction']
-            );
-
-            $bot_elephant_move = $game->selectBotElephantMove($game->board);
-
-            PlayerMovedElephant::fire(
-                game_id: $this->game_id,
-                player_id: $game->current_player_id,
-                space: $bot_elephant_move
-            );
-        }
-    }
-
     public function handle()
     {
         $game = Game::find($this->game_id);

--- a/app/Events/PlayerCreated.php
+++ b/app/Events/PlayerCreated.php
@@ -26,6 +26,8 @@ class PlayerCreated extends Event
 
     public bool $is_bot;
 
+    public ?bool $is_first_player = false;
+
     public function apply(PlayerState $state)
     {
         $state->game_id = $this->game_id;
@@ -45,11 +47,11 @@ class PlayerCreated extends Event
 
     public function applyToGame(GameState $state)
     {
-        $this->is_host
+        $this->is_first_player
             ? $state->player_1_id = $this->player_id
             : $state->player_2_id = $this->player_id;
 
-        $this->is_host
+        $this->is_first_player
             ? $state->player_1_victory_shape = $this->victory_shape
             : $state->player_2_victory_shape = $this->victory_shape;
     }
@@ -64,11 +66,12 @@ class PlayerCreated extends Event
             'is_bot' => $this->is_bot,
             'victory_shape' => $this->victory_shape,
             'wants_rematch' => $this->is_bot,
+            'is_first_player' => $this->is_first_player,
         ]);
 
         $game = Game::find($this->game_id);
 
-        if ($this->is_host) {
+        if ($this->is_first_player) {
             $game->current_player_id = $this->player_id;
             $game->save();
         }

--- a/app/Livewire/GameView.php
+++ b/app/Livewire/GameView.php
@@ -199,9 +199,11 @@ class GameView extends Component
         };
 
         $this->dispatch('opponent-moved-elephant', [
+            'elephant_move_id' => (string) $move->id,
             'elephant_move_position' => $move->elephant_after,
             'player_id' => (string) $move->player_id,
             'player_forfeits_at' => $this->player->fresh()->forfeits_at,
+            'tile_move_id' => (string) $prior_tile_move->id,
             'tile_direction' => $tile_direction,
             'tile_position' => $tile_position,
         ]);

--- a/app/Livewire/GameView.php
+++ b/app/Livewire/GameView.php
@@ -344,6 +344,7 @@ class GameView extends Component
                 is_friends_only: $this->game->is_friends_only,
                 is_ranked: $this->game->is_ranked,
                 is_rematch_from_game_id: $this->game->id,
+                is_first_player: ! $this->player_is_victor,
             );
 
             return redirect()->route('games.show', $game->id);

--- a/app/Livewire/PreGameLobby.php
+++ b/app/Livewire/PreGameLobby.php
@@ -77,7 +77,7 @@ class PreGameLobby extends Component
             victory_shape: $victory_shape,
         );
 
-        $this->user->closeInactiveGames();
+        $this->user->closeInactiveGamesBefore($this->game);
     }
 
     public function start()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -125,16 +125,16 @@ class User extends Authenticatable
         return 'not_friends';
     }
 
-    public function closeInactiveGames()
+    public function closeInactiveGamesBefore(Game $game)
     {
         $this->games
-            ->filter(fn($g) => $g->status === 'created' && $g->id !== $this->game_id)
+            ->filter(fn($g) => $g->status === 'created' && $g->id !== $game->id)
             ->each(function ($game) {
                 GameCanceled::fire(game_id: $game->id);
             });
 
         $this->games
-            ->filter(fn($g) => $g->status === 'active' && $g->id !== $this->game_id)
+            ->filter(fn($g) => $g->status === 'active' && $g->id !== $game->id)
             ->each(function ($game) {
                 $players = $game->players;
 

--- a/database/migrations/2024_12_30_215109_add_is_first_player_to_players_table.php
+++ b/database/migrations/2024_12_30_215109_add_is_first_player_to_players_table.php
@@ -1,0 +1,15 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('players', function (Blueprint $table) {
+            $table->boolean('is_first_player')->default(false);
+        });
+    }
+};

--- a/resources/views/livewire/game-view.blade.php
+++ b/resources/views/livewire/game-view.blade.php
@@ -21,9 +21,11 @@
             player_rating: {{ $this->player->user->rating }},
             opponent_rating: {{ $this->opponent->user->rating }},
             player_wants_rematch: {{ $this->player->wants_rematch ? 'true' : 'false' }},
+            known_move_ids: @json($this->moves->map(fn($move) => (string) $move->id)),
         };
 
         return {
+            known_move_ids: defaults.known_move_ids,
             player_wants_rematch: defaults.player_wants_rematch,
             player_rating: defaults.player_rating,
             opponent_rating: defaults.opponent_rating,
@@ -316,11 +318,17 @@
                 });
 
                 this.$wire.on('opponent-moved-elephant', (data) => {
-                    this.playTile(data[0].tile_direction, data[0].tile_position, data[0].player_id);
+                    if (!this.known_move_ids.includes(data[0].tile_move_id)) {
+                        this.playTile(data[0].tile_direction, data[0].tile_position, data[0].player_id);
+                        this.known_move_ids.push(data[0].tile_move_id);
+                    } 
 
-                    setTimeout(() => {
-                        this.moveElephant(data[0].player_id, data[0].elephant_move_position);
-                    }, 700);
+                    if (!this.known_move_ids.includes(data[0].elephant_move_id)) {
+                        setTimeout(() => {
+                            this.moveElephant(data[0].player_id, data[0].elephant_move_position);
+                            this.known_move_ids.push(data[0].elephant_move_id);
+                        }, 700);
+                    } 
 
                     this.player_forfeits_at = data[0].player_forfeits_at;
                 });

--- a/resources/views/livewire/home-page.blade.php
+++ b/resources/views/livewire/home-page.blade.php
@@ -64,6 +64,11 @@
                     </flux:field>
 
                     <flux:field variant="inline" class="w-full flex justify-between">
+                        <flux:switch wire:model.live="is_first_player" />
+                        <flux:label>Play first</flux:label>
+                    </flux:field>
+
+                    <flux:field variant="inline" class="w-full flex justify-between">
                         <flux:switch 
                             wire:model.live="is_ranked_game" 
                             x-bind:disabled="$wire.is_bot_game"

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -61,6 +61,7 @@ abstract class TestCase extends BaseTestCase
             is_host: true,
             is_bot: false,
             victory_shape: $victory_shape,
+            is_first_player: true,
         )->player_id;
 
         $this->player_1 = Player::find($player_1_id);
@@ -107,6 +108,7 @@ abstract class TestCase extends BaseTestCase
             is_host: true,
             is_bot: false,
             victory_shape: $victory_shape,
+            is_first_player: true,
         )->player_id;
 
         $player_2_id = PlayerCreated::fire(


### PR DESCRIPTION
Previously if you created a game, you automatically played first. Now you can forego this. Also, when rematching, the loser automatically goes first in the rematch. 

This also took a known bug from edge case to serious problem. The way the client works is that it does not animate your opponent's move until they have completed both the tile and the elephant. The reason for this is that it's easier to ensure that their whole turn gets animated correctly if we do it all at once. As a result, I introduced a bug where you could load the page while your opponent has played a tile, but has not yet moved the elephant. We would render everything correctly, then the client would hear the server event, and animate them again, showing an incorrect board. 

I introduced a simple solution for this. The client now tracks an array of `known_move_ids` for everything it has already rendered. When new moves come in from the server, we skip them if we already know about them. 