### PR TITLE
Cleanup winning spaces

### DIFF
--- a/app/Events/PlayerPlayedTile.php
+++ b/app/Events/PlayerPlayedTile.php
@@ -132,6 +132,7 @@ class PlayerPlayedTile extends Event
             $state->winning_spaces = collect($state->victor_ids)
                 ->map(fn($v_id) => $this->state(GameState::class)->winningSpaces(PlayerState::load($v_id), $state->board))
                 ->values()
+                ->unique()
                 ->flatten()
                 ->toArray();
     

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -39,8 +39,6 @@ class Game extends Model
         
         $victory_shape = collect(['square', 'line', 'el', 'zig', 'pyramid'])->random();
 
-        $victory_shape = 'square';
-
         PlayerCreated::fire(
             game_id: $game_id,
             user_id: $user->id,

--- a/app/Models/Game.php
+++ b/app/Models/Game.php
@@ -39,6 +39,8 @@ class Game extends Model
         
         $victory_shape = collect(['square', 'line', 'el', 'zig', 'pyramid'])->random();
 
+        $victory_shape = 'square';
+
         PlayerCreated::fire(
             game_id: $game_id,
             user_id: $user->id,

--- a/app/States/Traits/BoardLogic.php
+++ b/app/States/Traits/BoardLogic.php
@@ -192,18 +192,24 @@ trait BoardLogic
             default => [],
         };
 
-        return collect($possible_victory_sets)
+        $winning_sets = collect($possible_victory_sets)
             ->filter(fn($set) => 
                 collect($set)
                     ->reduce(function (int $spaces_in_set_occupied_by_player, int $space) use($board, $player) {
                         return $spaces_in_set_occupied_by_player + ($board[$space] === (string) $player->id ? 1 : 0);
                     }, 0) === 4
-            )
-            ->toArray();
+            );
+
+        if ($winning_sets->count() === 0) {
+            return [];
+        }
+
+        return $winning_sets->first();
     }
 
     public function isVictorious(PlayerState $player, array $board)
     {
+        dump($this->winningSpaces($player, $board));
         return count($this->winningSpaces($player, $board)) > 0;
     }
 

--- a/app/States/Traits/BoardLogic.php
+++ b/app/States/Traits/BoardLogic.php
@@ -209,7 +209,6 @@ trait BoardLogic
 
     public function isVictorious(PlayerState $player, array $board)
     {
-        dump($this->winningSpaces($player, $board));
         return count($this->winningSpaces($player, $board)) > 0;
     }
 

--- a/resources/js/game/game-logic.js
+++ b/resources/js/game/game-logic.js
@@ -14,10 +14,6 @@ export function victory_status(tiles, victoryShape, playerId) {
         return winning_spaces_occupied === 4;
     });
 
-    if (winning_set) {
-        console.log('winning_set', winning_set, 'playerId', playerId, 'board', board, 'tiles', tiles);
-    }
-
     return {
         has_won: !!winning_set,
         winning_spaces: winning_set ?? []

--- a/resources/js/game/game-logic.js
+++ b/resources/js/game/game-logic.js
@@ -14,9 +14,13 @@ export function victory_status(tiles, victoryShape, playerId) {
         return winning_spaces_occupied === 4;
     });
 
+    if (winning_set) {
+        console.log('winning_set', winning_set, 'playerId', playerId, 'board', board, 'tiles', tiles);
+    }
+
     return {
         has_won: !!winning_set,
-        winning_spaces: winning_set || []
+        winning_spaces: winning_set ?? []
     };
 }
 


### PR DESCRIPTION
Previously the array `winning_spaces` contained all spaces for all possible winning configurations. this meant that if one player had multiple shapes that could make them victorious, all of those spaces would be highlighted, and it was confusing. Now we just select one set of winning victory shapes and that's it.